### PR TITLE
Add HDF5_NO_FIND_PACKAGE_CONFIG_FILE to cmake opts

### DIFF
--- a/var/spack/repos/builtin/packages/fenics/package.py
+++ b/var/spack/repos/builtin/packages/fenics/package.py
@@ -131,6 +131,7 @@ class Fenics(CMakePackage):
             self.define_from_variant('DOLFIN_ENABLE_OPENMP', 'openmp'),
             self.define_from_variant('DOLFIN_ENABLE_CHOLMOD', 'suite-sparse'),
             self.define_from_variant('DOLFIN_ENABLE_HDF5', 'hdf5'),
+            self.define_from_variant('HDF5_NO_FIND_PACKAGE_CONFIG_FILE', 'hdf5'),
             self.define_from_variant('DOLFIN_ENABLE_MPI', 'mpi'),
             self.define_from_variant('DOLFIN_ENABLE_PARMETIS', 'parmetis'),
             self.define_from_variant('DOLFIN_ENABLE_PETSC', 'petsc'),


### PR DESCRIPTION
In some cases the FindHDF5.cmake returnd a wrong value for the HDF5 library names and path. For example it returns `hdf5-shared` as library name without a search path or checking if this is really an existing shared library. 

By `HDF5_NO_FIND_PACKAGE_CONFIG_FILE=True/ON`  to the cmake options, the FindHDF5 module does not rely on a properly installed `hdf5-config.cmake` and thus searches for the library and its paths. This results in a usable return value and fenics works afterwards.